### PR TITLE
Add focus outline for keyboard navigation

### DIFF
--- a/apps/front-end/src/components/Button.tsx
+++ b/apps/front-end/src/components/Button.tsx
@@ -3,7 +3,7 @@ import { VariantProps, cva } from "class-variance-authority";
 import { ComponentPropsWithoutRef, forwardRef } from "react";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-md  text-center shadow-sm md:px-4 md:py-2",
+  "inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-md  text-center shadow-sm ring-cyan-600 ring-offset-2 ring-offset-slate-900 focus-visible:outline-none focus-visible:ring-2 md:px-4 md:py-2",
   {
     variants: {
       variant: {

--- a/apps/front-end/src/components/Sidebar/Item.tsx
+++ b/apps/front-end/src/components/Sidebar/Item.tsx
@@ -64,10 +64,10 @@ type SidebarItemProps = ItemWithParent<{
 const UNTITLED_PAGE_TITLE = "Untitled";
 
 export const itemVariant = {
-  root: "rounded-lg p-3 text-left",
+  root: "rounded-lg p-3 text-left break-words ring-cyan-600 focus-visible:outline-none focus-visible:ring-2 ring-inset",
   active:
     "dark:bg-cyan-900 bg-cyan-400/20  dark:text-cyan-200 text-cyan-950 dark:hover:bg-cyan-800\
-     hover:bg-gray-300 hover:bg-cyan-400/30",
+     hover:bg-gray-300 hover:bg-cyan-400/30 ",
   inactive:
     "hover:bg-gray-300 dark:hover:bg-slate-700\
     focus-within:dark:bg-slate-700 focus-within:bg-gray-300",

--- a/apps/front-end/src/components/Sidebar/Sidebar.tsx
+++ b/apps/front-end/src/components/Sidebar/Sidebar.tsx
@@ -78,7 +78,7 @@ export function SidebarButton({ children, ...props }: SidebarButtonProps) {
   return (
     <button
       type="button"
-      className="flex w-full items-center justify-between rounded-lg p-3 hover:bg-gray-300 dark:hover:bg-gray-700"
+      className="flex w-full items-center justify-between rounded-lg p-3 ring-cyan-600 hover:bg-gray-300 focus-visible:outline-none focus-visible:ring-2 dark:hover:bg-gray-700"
       {...props}
     >
       {children}


### PR DESCRIPTION
We were missing focus-visible outlines on many of the critical buttons. This PR adds a standard "ring" on all the critical buttons.